### PR TITLE
Add rexml deps for Ruby 3

### DIFF
--- a/s3RubySDKExample/sample/Gemfile
+++ b/s3RubySDKExample/sample/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 gem 'aws-sdk-s3', '< 1.178' # freeze due to change in aws-sdk-core that replaces content-md5 with newer checksum methods
 gem 'aws-sdk-core', '< 3.216'
+gem 'rexml', '< 4.0'

--- a/s3RubySDKExample/sample/Gemfile.lock
+++ b/s3RubySDKExample/sample/Gemfile.lock
@@ -18,6 +18,7 @@ GEM
     aws-sigv4 (1.11.0)
       aws-eventstream (~> 1, >= 1.0.2)
     jmespath (1.6.2)
+    rexml (3.4.1)
 
 PLATFORMS
   ruby
@@ -25,6 +26,7 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk-core (< 3.216)
   aws-sdk-s3 (< 1.178)
+  rexml (< 4.0)
 
 BUNDLED WITH
    2.4.22


### PR DESCRIPTION
Exception when switched to Ruby 3
```
/.ruby/gems/aws-sdk-core-3.215.1/lib/aws-sdk-core/xml/parser.rb:71:in `set_default_engine': Unable to find a compatible xml library. Ensure that you have installed or added to your Gemfile one of ox, oga, libxml, nokogiri or rexml (RuntimeError)
```

Reference: https://stackoverflow.com/a/75094719