### PR TITLE
Pinned php version to 3.343.* to fix malformed xml error 

### DIFF
--- a/s3PhpSDKExample/sample/composer.json
+++ b/s3PhpSDKExample/sample/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "aws/aws-sdk-php": "^3.343"
+        "aws/aws-sdk-php": "~3.343.0"
     }
 }


### PR DESCRIPTION
Pinned php version to 3.343.* to fix malformed xml error when put lifecycle